### PR TITLE
Fix nextflow include in workflow block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
-        nxf_ver: [ 21.04.0 ]
+        nxf_ver: [ 21.04.0, 21.10.0 ]
         profile: [ test, test_gisaid ]
     steps:
       - name: Check out pipeline code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.5.1](https://github.com/CFIA-NCFAD/scovtree/releases/tag/1.5.1) - [2021-11-12]
+
+### Fixes
+
+* Since Nextflow [v21.06.0-edge](https://github.com/nextflow-io/nextflow/releases/tag/v21.06.0-edge) (commit [7dbf64b](https://github.com/nextflow-io/nextflow/commit/7dbf64bea38907126f44b09a023b8061bf3363d0)), `include` is not allowed within a `workflow` block. Moved `include` from `workflow` block in `main.nf` so that workflow is compatible with later versions of Nextflow.
+
 ## [v1.5.0](https://github.com/CFIA-NCFAD/scovtree/releases/tag/1.5.0) - [2021-11-12]
 
 ### Updates

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -432,7 +432,7 @@ nextflow pull CFIA-NCFAD/scovtree
 
 It's a good idea to specify a pipeline version when running the pipeline on your data. This ensures that a specific version of the pipeline code and software are used when you run your pipeline. If you keep using the same tag, you'll be running the same version of the pipeline, even if there have been changes to the code since.
 
-First, go to the [CFIA-NCFAD/scovtree releases page](https://github.com/CFIA-NCFAD/scovtree/releases) and find the latest version number - numeric only (eg. `1.3.1`). Then specify this when running the pipeline with `-r` (one hyphen) - eg. `-r 1.5.0`.
+First, go to the [CFIA-NCFAD/scovtree releases page](https://github.com/CFIA-NCFAD/scovtree/releases) and find the latest version number - numeric only (eg. `1.3.1`). Then specify this when running the pipeline with `-r` (one hyphen) - eg. `-r 1.5.1`.
 
 This version number will be logged in reports when you run the pipeline, so that you'll know what you used when you look back in the future.
 

--- a/main.nf
+++ b/main.nf
@@ -29,15 +29,14 @@ if (params.validate_params) {
 ////////////////////////////////////////////////////
 log.info NfcoreSchema.params_summary_log(workflow, params, json_schema)
 
+include { PHYLOGENETIC_ANALYSIS } from './workflows/phylogenetic_analysis'
+include { PHYLOGENETIC_GISAID } from './workflows/phylogenetic_gisaid'
+
 workflow {
     if (params.gisaid_sequences && params.gisaid_metadata){
-        include { PHYLOGENETIC_GISAID } from './workflows/phylogenetic_gisaid'
-
         PHYLOGENETIC_GISAID()
     }
     else {
-        include { PHYLOGENETIC_ANALYSIS } from './workflows/phylogenetic_analysis'
-
         PHYLOGENETIC_ANALYSIS()
     }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -172,7 +172,7 @@ manifest {
   description = 'Phylogenetic Analysis for SARS-CoV-2'
   mainScript = 'main.nf'
   nextflowVersion = '!>=21.04.0'
-  version = '1.5.0'
+  version = '1.5.1'
 }
 
 // Function to ensure that resource requirements don't go beyond


### PR DESCRIPTION
Since Nextflow [v21.06.0-edge](https://github.com/nextflow-io/nextflow/releases/tag/v21.06.0-edge) (commit [7dbf64b](https://github.com/nextflow-io/nextflow/commit/7dbf64bea38907126f44b09a023b8061bf3363d0)), `include` is not allowed within a `workflow` block. Moved `include` from `workflow` block in `main.nf` so that workflow is compatible with later versions of Nextflow.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [X] Usage Documentation in `docs/usage.md` is updated.
- [X] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [X] `README.md` is updated (including new tool citations and authors/contributors).
