### PR TITLE
v1.6.0 User metadata update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Updates
 
-- Pangolin: 3.1.16 → 3.1.17
+* Pangolin: 3.1.16 → 3.1.17
 
 ### Enhancements
 
-- Nextclade amino acid (AA) deletions also included in AA mutation matrix and can be visualized along with AA substitutions in shiptv tree.
-- Users can filter GISAID sequences by collection date (`--gisaid_date_start`, `--gisaid_date_end`), Pangolin lineage (`--gisaid_pangolin_lineages "AY.4,AY44"`), multiple countries and regions.  
-- users can specify input sequence metadata table with `--input_metadata` workflow parameter. Must be CSV or TSV file.
-- update usage docs to include how to update process containers/packages (e.g. update Pangolin without changing workflow). Borrowed from nf-core/viralrecon.
-- Log files now output for most processes.
+* Nextclade amino acid (AA) deletions also included in AA mutation matrix and can be visualized along with AA substitutions in shiptv tree.
+* Users can filter GISAID sequences by collection date (`--gisaid_date_start`, `--gisaid_date_end`), Pangolin lineage (`--gisaid_pangolin_lineages "AY.4,AY44"`), multiple countries and regions.  
+* users can specify input sequence metadata table with `--input_metadata` workflow parameter. Must be CSV or TSV file.
+* update usage docs to include how to update process containers/packages (e.g. update Pangolin without changing workflow). Borrowed from nf-core/viralrecon.
+* Log files now output for most processes.
 
 ### Fixes
 
-- allocate more memory for `FILTER_GISAID` process by default (6GB -> 16GB) due to growing size of GISAID DB
-- handle all metadata as string so that numeric sequence IDs are not treated as int/float leading to issues with merging of metadata and tracking sequences to keep for further analysis
+* allocate more memory for `FILTER_GISAID` process by default (6GB -> 16GB) due to growing size of GISAID DB
+* handle all metadata as string so that numeric sequence IDs are not treated as int/float leading to issues with merging of metadata and tracking sequences to keep for further analysis
 
 ## [v1.5.1](https://github.com/CFIA-NCFAD/scovtree/releases/tag/1.5.1) - [2021-11-12]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.6.0](https://github.com/CFIA-NCFAD/scovtree/releases/tag/1.6.0) - [2021-12-14]
+## [v1.6.0](https://github.com/CFIA-NCFAD/scovtree/releases/tag/1.6.0) - [2021-12-19]
 
 ### Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.6.0](https://github.com/CFIA-NCFAD/scovtree/releases/tag/1.6.0) - [2021-12-14]
+
+### Updates
+
+- Pangolin: 3.1.16 → 3.1.17
+
+### Enhancements
+
+- Nextclade amino acid (AA) deletions also included in AA mutation matrix and can be visualized along with AA substitutions in shiptv tree.
+- Users can filter GISAID sequences by collection date (`--gisaid_date_start`, `--gisaid_date_end`), Pangolin lineage (`--gisaid_pangolin_lineages "AY.4,AY44"`), multiple countries and regions.  
+- users can specify input sequence metadata table with `--input_metadata` workflow parameter. Must be CSV or TSV file.
+- update usage docs to include how to update process containers/packages (e.g. update Pangolin without changing workflow). Borrowed from nf-core/viralrecon.
+- Log files now output for most processes.
+
+### Fixes
+
+- allocate more memory for `FILTER_GISAID` process by default (6GB -> 16GB) due to growing size of GISAID DB
+- handle all metadata as string so that numeric sequence IDs are not treated as int/float leading to issues with merging of metadata and tracking sequences to keep for further analysis
+
 ## [v1.5.1](https://github.com/CFIA-NCFAD/scovtree/releases/tag/1.5.1) - [2021-11-12]
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ The pipeline is built using [Nextflow], a workflow tool to run tasks across mult
         ```bash
         nextflow run CFIA-NCFAD/scovtree -profile <docker/singularity/conda> \
             --input your-sars-cov-2-sequences.fasta \
-            --gisaid_sequences sequences_fasta_2021_06_14.tar.xz \
-            --gisaid_metadata metadata_tsv_2021_06_14.tar.xz
+            --input_metadata your-sars-cov-2-sequences-metadata.tsv \
+            --gisaid_sequences sequences_fasta_2021_12_01.tar.xz \
+            --gisaid_metadata metadata_tsv_2021_12_01.tar.xz
         ```
 
 ## Credits
@@ -62,7 +63,6 @@ For further information or help, don't hesitate to get in touch on the [Slack `#
 
 ## Citations
 
-<!-- TODO nf-core: Add citation for pipeline after first release. Uncomment lines below and update Zenodo doi. -->
 <!-- If you use  CFIA-NCFAD/scovtree for your analysis, please cite it using the following doi: [10.5281/zenodo.XXXXXX](https://doi.org/10.5281/zenodo.XXXXXX) -->
 This pipeline tries to follow the best practices for Nextflow workflow development and deployment set by `nf-core`. You can cite the `nf-core` publication as follows:
 

--- a/bin/aa_mutation_matrix.py
+++ b/bin/aa_mutation_matrix.py
@@ -6,22 +6,16 @@ from typing import Set, List, Dict
 import numpy as np
 import pandas as pd
 import typer
+from rich.console import Console
 from rich.logging import RichHandler
 
 
 def main(nextclade_csv: Path, metadata_output: Path):
-    from rich.traceback import install
-    install(show_locals=True, width=120, word_wrap=True)
-    logging.basicConfig(
-        format="%(message)s",
-        datefmt="[%Y-%m-%d %X]",
-        level=logging.INFO,
-        handlers=[RichHandler(rich_tracebacks=True, tracebacks_show_locals=True)],
-    )
-    df_nextclade = pd.read_table(nextclade_csv, sep=';')
-    # remove surrounding brackets, split on ',' to get Series of list of str AA mutations
-    aasubs: pd.Series = df_nextclade['aaSubstitutions'].str.replace(r'^(\(|\))$', '', regex=True).str.split(',')
-    sample_aas = sample_to_aa_mutations(aasubs, df_nextclade['seqName'])
+    init_logging()
+    df_nextclade = pd.read_table(nextclade_csv, sep=';', dtype=str, index_col=0)
+    aa_subs: pd.Series = df_nextclade['aaSubstitutions'].str.split(',')
+    aa_dels: pd.Series = df_nextclade['aaDeletions'].str.split(',')
+    sample_aas = sample_to_aa_mutations(aa_subs, aa_dels)
     samples = list(sample_aas.keys())
     unique_aas = get_sorted_aa_mutations(sample_aas)
     arr_aas = fill_aa_mutation_matrix(sample_aas, samples, unique_aas)
@@ -29,12 +23,27 @@ def main(nextclade_csv: Path, metadata_output: Path):
     dfaa.to_csv(metadata_output, sep='\t')
 
 
-def sample_to_aa_mutations(aasubs: pd.Series, seq_name: pd.Series) -> Dict[str, Set[str]]:
+def init_logging():
+    from rich.traceback import install
+    console = Console(stderr=True, width=120)
+    install(show_locals=True, width=120, word_wrap=True, console=console)
+    logging.basicConfig(
+        format="%(message)s",
+        datefmt="[%Y-%m-%d %X]",
+        level=logging.INFO,
+        handlers=[RichHandler(rich_tracebacks=True, tracebacks_show_locals=True, console=console)],
+    )
+
+
+def sample_to_aa_mutations(
+        aa_subs: pd.Series,
+        aa_dels: pd.Series
+) -> Dict[str, Set[str]]:
     sample_aas = {}
-    for sample, aas in zip(seq_name, aasubs):
-        if not isinstance(aas, list):
-            continue
-        sample_aas[sample] = set(aas)
+    for sample, aa_sub, aa_del in zip(aa_subs.index, aa_subs, aa_dels):
+        aas = [] if not isinstance(aa_sub, list) else aa_sub
+        aad = [] if not isinstance(aa_del, list) else aa_del
+        sample_aas[sample] = set(aas) | set(aad)
     return sample_aas
 
 
@@ -53,7 +62,7 @@ def fill_aa_mutation_matrix(
     return arr_aas
 
 
-def get_sorted_aa_mutations(sample_aas):
+def get_sorted_aa_mutations(sample_aas: Dict[str, Set[str]]) -> List[str]:
     unique_aas = set()
     for aas in sample_aas.values():
         unique_aas |= aas

--- a/bin/filter_gisaid.py
+++ b/bin/filter_gisaid.py
@@ -1,23 +1,24 @@
 #!/usr/bin/env python
 import logging
+import re
 import sys
 import tarfile
 from pathlib import Path
-from typing import Iterator, Tuple, Optional, IO, Set
-import re
+from typing import Iterator, Tuple, Optional, IO, Set, Dict, Any
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 import typer
 from Bio.SeqIO.FastaIO import SimpleFastaParser
+from rich.console import Console
 from rich.logging import RichHandler
 
 
 def main(
-        sequences: Path,
-        gisaid_sequences: Path,
-        gisaid_metadata: Path,
-        lineage_report: Path,
+        user_fasta: Path,
+        gisaid_fasta: Path,
+        gisaid_tsv: Path,
+        pangolin_report: Path,
         min_length: int = typer.Option(28000, help='Minimum length for GISAID sequences'),
         max_length: int = typer.Option(31000, help='Maximum length for GISAID sequences'),
         max_ambig: int = typer.Option(3000, help='Max number of ambiguous base sites in GISAID sequences allowed'),
@@ -28,6 +29,12 @@ def main(
                                                'belonging to this country.'),
         region: str = typer.Option(None, help='If specified, filter for GISAID sequences '
                                               'belonging to this geographical region.'),
+        date_start: str = typer.Option(None,
+                                       help='Filter for sequences collected starting on this date. Must be ISO format date (YY-mm-dd), e.g. 2021-12-13'),
+        date_end: str = typer.Option(None,
+                                     help='Filter for sequences collected until this date. Must be ISO format date (YY-mm-dd), e.g. 2021-12-13'),
+        pangolin_lineages: str = typer.Option(None, help='Comma-delimited list of additional Pangolin lineages to '
+                                                         'filter for (e.g. "AY.44,AY.43,AY.4,AY.25"'),
         fasta_output: Path = typer.Option(Path('gisaid_sequences.filtered.fasta'),
                                           help='Filtered GISAID sequences.'),
         filtered_metadata: Path = typer.Option(Path('gisaid_metadata.filtered.tsv'),
@@ -37,90 +44,176 @@ def main(
         statistics_output: Path = typer.Option(Path('gisaid_stats.json'),
                                                help='GISAID filtering stats.')
 ):
-    from rich.traceback import install
-    install(show_locals=True, width=200, word_wrap=True)
-    logging.basicConfig(
-        format="%(message)s",
-        datefmt="[%Y-%m-%d %X]",
-        level=logging.INFO,
-        handlers=[RichHandler(rich_tracebacks=True, tracebacks_show_locals=True, locals_max_string=200)],
-    )
-    df_lineage_report = pd.read_csv(lineage_report, index_col=0)
-    sample_lineages = set(df_lineage_report['lineage'])
+    init_logging()
+    df_pangolin = pd.read_csv(pangolin_report, dtype=str)
+    df_pangolin.set_index(df_pangolin.columns[0], inplace=True)
+    sample_lineages = set(df_pangolin['lineage'])
+    sample_lineages.remove('None')
     logging.info(f'{len(sample_lineages)} unique Pangolin lineages for user sequences: {sample_lineages}')
-    df_gisaid = read_gisaid_metadata(gisaid_metadata)
-    logging.info(
-        f'Read GISAID metadata table from "{gisaid_metadata}"; {df_gisaid.shape[0]} rows and {df_gisaid.shape[1]} columns')
+    df_gisaid = read_gisaid_metadata(gisaid_tsv)
+    logging.info(f'Read GISAID metadata table from "{gisaid_tsv}"; '
+                 f'{df_gisaid.shape[0]} rows and {df_gisaid.shape[1]} columns')
+    gisaid_lineages = df_gisaid['Pango_lineage']
+    if pangolin_lineages:
+        pangolin_lineages = set(pangolin_lineages.split(','))
+        logging.info(f'Filtering for specified Pangolin lineages: {pangolin_lineages}')
+        sample_lineages |= pangolin_lineages
+    mask: pd.Series = gisaid_lineages.isin(sample_lineages)
+    n_gisaid_matching_lineage = int(mask.sum())
+    logging.info(f'{n_gisaid_matching_lineage} GISAID sequences matching lineages: {sample_lineages}')
+    if date_start:
+        dt_start: pd.Timestamp = pd.to_datetime(date_start, errors='coerce')
+        if not pd.isna(dt_start):
+            collection_datetimes: pd.Series = pd.to_datetime(df_gisaid['Collection_date'], errors='coerce')
+            dt_start_mask: pd.Series = (collection_datetimes >= dt_start)
+            mask = mask & dt_start_mask
+            logging.info(f'{mask.sum()} GISAID sequences filtered starting {dt_start}. {dt_start_mask.sum()}')
+        else:
+            logging.info(f'Could not parse datetime from "{date_start}". No date filtering applied.')
 
-    gisaid_pango_lineage = df_gisaid['Pango_lineage']
-    mask: pd.Series = gisaid_pango_lineage.isin(sample_lineages)
-    n_gisaid_matching_lineage = mask.sum()
-    logging.info(f'Found {n_gisaid_matching_lineage} GISAID sequences matching lineages {sample_lineages}.')
+    if date_end:
+        dt_end: pd.Timestamp = pd.to_datetime(date_end, errors='coerce')
+        if not pd.isna(dt_end):
+            collection_datetimes: pd.Series = pd.to_datetime(df_gisaid['Collection_date'], errors='coerce')
+            dt_end_mask: pd.Series = (collection_datetimes <= dt_end)
+            mask = mask & dt_end_mask
+            logging.info(f'{mask.sum()} GISAID sequences filtered ending {dt_end}.')
+        else:
+            logging.info(f'Could not parse datetime from "{date_start}". No date filtering applied.')
+
     if country:
-        mask = mask & df_gisaid['country'].str.contains(country)
-        logging.info(f'{mask.sum()} GISAID sequences after filtering for country "{country}"')
+        if ',' in country:
+            countries = [x.strip() for x in country.split(',') if x.strip() != '']
+            mask = mask & df_gisaid['country'].isin(countries)
+            logging.info(f'{mask.sum()} GISAID sequences after filtering for countries: {countries}')
+        else:
+            mask = mask & df_gisaid['country'].str.contains(country)
+            logging.info(f'{mask.sum()} GISAID sequences after filtering for country "{country}"')
     if region:
-        mask = mask & df_gisaid['region'].str.contains(region)
-        logging.info(f'{mask.sum()} GISAID sequences after filtering for region "{region}"')
+        if ',' in region:
+            regions = [x.strip() for x in region.split(',') if x.strip() != '']
+            mask = mask & df_gisaid['region'].isin(regions)
+            logging.info(f'{mask.sum()} GISAID sequences after filtering for regions: "{regions}"')
+        else:
+            mask = mask & df_gisaid['region'].str.contains(region)
+            logging.info(f'{mask.sum()} GISAID sequences after filtering for region "{region}"')
     df_subset: pd.DataFrame = df_gisaid.loc[mask, :]
     # drop duplicate entries of df_subset before filtering/sampling
     df_subset = df_subset[~df_subset.index.duplicated()]  # default keep first occurrence
     logging.info(f'{df_subset.shape[0]} interest strains found ')
     if df_subset.index.size > max_gisaid_seqs:
         logging.warning(f'There are {df_subset.index.size} GISAID sequences selected by metadata. '
-                        f'Downsampling to {max_gisaid_seqs}')
+                        f'Down-sampling to {max_gisaid_seqs}')
         sampled_gisaid = sampling_gisaid(df_subset, max_gisaid_seqs)
         df_subset = df_subset.loc[sampled_gisaid, :]
     metadata_filtered_sequences = set(df_subset.index)
     if not metadata_filtered_sequences:
         logging.error(f'No GISAID sequences found matching filters!')
         sys.exit(1)
+    logging.info(f'Writing output FASTA with up to {len(metadata_filtered_sequences)} metadata filtered sequences to '
+                 f'"{fasta_output}". Performing additional filtering for sequences with up to {max_ambig} ambiguous '
+                 f'bases and length between {min_length} and {max_length}.')
+    keep_samples: Set[str] = write_fasta(
+        fasta_output,
+        gisaid_fasta,
+        max_ambig,
+        max_length,
+        metadata_filtered_sequences,
+        min_length,
+        user_fasta
+    )
+    logging.info(f'Wrote {len(keep_samples)} sequences to "{fasta_output}"')
+    logging.info(f'Writing filtered metadata table with {keep_samples} entries to "{filtered_metadata}"')
+    df_filtered = write_filtered_metadata(df_subset, filtered_metadata, keep_samples)
+    logging.info(f'Writing Nextstrain metadata table to "{nextstrain_metadata}"')
+    write_nextstrain_metadata(df_filtered, nextstrain_metadata)
+    if statistics_output:
+        lineage_counts = get_lineage_counts(gisaid_lineages, mask)
+        stats = write_stats(
+            output_path=statistics_output,
+            gisaid_matching_lineage_counts=lineage_counts,
+            n_total_gisaid_sequences=df_gisaid.shape[0],
+            n_total_gisaid_lineages=gisaid_lineages.unique().size,
+            n_gisaid_matching_lineage=n_gisaid_matching_lineage,
+            n_metadata_filtered_sequences=df_subset.shape[0],
+            n_final_filtered_sequences=df_filtered.shape[0],
+            sample_lineages=sample_lineages
+        )
+        logging.info(f'Wrote GISAID filtering stats to "{statistics_output}"')
+        logging.info(f'Filtering stats: {stats}')
+    logging.info('Done!')
 
-    with open(fasta_output, 'w') as fout:
-        write_user_sequences(fasta_output, fout, sequences)
-        if tarfile.is_tarfile(gisaid_sequences):
-            logging.info(f'GISAID sequences provided as TAR file "{gisaid_sequences}"')
-            iterator = read_fasta_tarxz(gisaid_sequences)
-            keep_samples = write_good_seqs(
-                iterator,
-                metadata_filtered_sequences,
-                fout,
-                min_length,
-                max_length,
-                max_ambig
-            )
-        else:
-            with open(gisaid_sequences) as fin:
-                iterator = SimpleFastaParser(fin)
-                keep_samples = write_good_seqs(
-                    iterator,
-                    metadata_filtered_sequences,
-                    fout,
-                    min_length,
-                    max_length,
-                    max_ambig
-                )
+
+def get_lineage_counts(gisaid_lineages: pd.Series, mask: pd.Series) -> Dict[str, int]:
+    return gisaid_lineages[mask].value_counts().to_dict()
+
+
+def parse_fasta(gisaid_sequences: Path):
+    with open(gisaid_sequences) as fin:
+        yield SimpleFastaParser(fin)
+
+
+def write_filtered_metadata(
+        df_subset: pd.DataFrame,
+        filtered_metadata: Path,
+        keep_samples: Set[str]
+) -> pd.DataFrame:
     df_filtered = df_subset.loc[keep_samples, :]
     df_filtered.to_csv(filtered_metadata, sep='\t', index=True)
+    return df_filtered
 
-    write_nextstrain_metadata(df_filtered, nextstrain_metadata)
 
-    if statistics_output:
-        import json
-        gisaid_matching_lineage_counts = gisaid_pango_lineage[gisaid_pango_lineage.isin(sample_lineages)] \
-            .value_counts().to_dict()
-        gisaid_matching_lineage_counts = {k: int(v) for k, v in gisaid_matching_lineage_counts.items()}
-        stats = dict(
-            sample_lineages=list(sample_lineages),
-            n_total_gisaid_sequences=int(df_gisaid.shape[0]),
-            n_total_gisaid_lineages=int(gisaid_pango_lineage.unique().size),
-            n_gisaid_matching_lineage=int(n_gisaid_matching_lineage),
-            gisaid_matching_lineage_counts=gisaid_matching_lineage_counts,
-            n_metadata_filtered_sequences=int(df_subset.shape[0]),
-            n_total_filtered_sequences=int(df_filtered.shape[0])
-        )
-        with open(statistics_output, 'w') as fh:
-            json.dump(stats, fh)
+def write_stats(
+        output_path: Path,
+        gisaid_matching_lineage_counts: Dict[str, int],
+        n_total_gisaid_sequences: int,
+        n_gisaid_matching_lineage: int,
+        n_total_gisaid_lineages: int,
+        n_metadata_filtered_sequences: int,
+        n_final_filtered_sequences: int,
+        sample_lineages: Set[str]
+) -> Dict[str, Any]:
+    import json
+    stats = dict(
+        sample_lineages=list(sample_lineages),
+        n_total_gisaid_sequences=n_total_gisaid_sequences,
+        n_total_gisaid_lineages=n_total_gisaid_lineages,
+        n_gisaid_matching_lineage=n_gisaid_matching_lineage,
+        gisaid_matching_lineage_counts=gisaid_matching_lineage_counts,
+        n_metadata_filtered_sequences=n_metadata_filtered_sequences,
+        n_final_filtered_sequences=n_final_filtered_sequences
+    )
+    with open(output_path, 'w') as fh:
+        json.dump(stats, fh)
+    return stats
+
+
+def write_fasta(fasta_output, gisaid_sequences, max_ambig, max_length, metadata_filtered_sequences, min_length,
+                sequences):
+    with open(fasta_output, 'w') as fout:
+        n_user_sequences = write_user_sequences(fout, sequences)
+        logging.info(f'Wrote {n_user_sequences} user sequences to "{fasta_output}"')
+        is_tarred = tarfile.is_tarfile(gisaid_sequences)
+        logging.info(f'GISAID sequences from "{gisaid_sequences}" provided as {"TAR" if is_tarred else "FASTA"} file')
+        iterator = read_fasta_tarxz(gisaid_sequences) if is_tarred else parse_fasta(gisaid_sequences)
+        keep_samples = write_filtered_gisaid_seqs(fout, iterator, metadata_filtered_sequences, min_length, max_length,
+                                                  max_ambig)
+    return keep_samples
+
+
+def init_logging():
+    from rich.traceback import install
+    console = Console(stderr=True, width=200)
+    install(show_locals=True, width=200, word_wrap=True, console=console)
+    logging.basicConfig(
+        format="%(message)s",
+        datefmt="[%Y-%m-%d %X]",
+        level=logging.INFO,
+        handlers=[RichHandler(rich_tracebacks=True,
+                              tracebacks_show_locals=True,
+                              locals_max_string=None,
+                              console=console)],
+    )
 
 
 def sampling_gisaid(df: pd.DataFrame, max_gisaid_seqs: int) -> Set[str]:
@@ -132,7 +225,9 @@ def sampling_gisaid(df: pd.DataFrame, max_gisaid_seqs: int) -> Set[str]:
         seqs_in_lineages = df[df['Pango_lineage'] == lineage]
         if row['count'] < seqs_per_lineages:
             logging.info(
-                f'No need to sample lineage "{lineage}" (sequences count={row["count"]}; less than {seqs_per_lineages} seqs per lineage)')
+                f'No need to sample lineage "{lineage}" (sequences '
+                f'count={row["count"]}; less than {seqs_per_lineages} seqs '
+                f'per lineage)')
             sampled_gisaid |= set(seqs_in_lineages.index)
         else:
             try:
@@ -140,26 +235,31 @@ def sampling_gisaid(df: pd.DataFrame, max_gisaid_seqs: int) -> Set[str]:
                 weights[np.isnan(weights)] = 0.0
                 weights = np.clip(weights, 0.0, 1.0)
                 logging.info(
-                    f'Using GISAID provided N content for down-sampling weights for {lineage}, (sequences count={row["count"]}; greater than {seqs_per_lineages} seqs per lineage)'
+                    f'Using GISAID provided N content for down-sampling '
+                    f'weights for {lineage}, (sequences count={row["count"]}; '
+                    f'greater than {seqs_per_lineages} seqs per lineage)'
                     f'. Mean N content: {seqs_in_lineages["N_Content"].mean()}')
                 sampled_gisaid |= set(seqs_in_lineages.index.to_series().sample(n=seqs_per_lineages, weights=weights))
             except ValueError as ex:
                 logging.warning(
-                    f'Could not use weights based on "N_Content" GISAID metadata field, using equal probability weights for down-sampling {lineage}'
-                    f'(sequences count={row["count"]}; greater than {seqs_per_lineages} seqs per lineage). Error: "{ex}"')
+                    f'Could not use weights based on "N_Content" GISAID '
+                    f'metadata field, using equal probability weights for '
+                    f'down-sampling {lineage} (sequences count={row["count"]};'
+                    f' greater than {seqs_per_lineages} seqs per lineage). '
+                    f'Error: "{ex}"')
                 sampled_gisaid |= set(seqs_in_lineages.index.to_series().sample(n=seqs_per_lineages))
         if n_lineages < i + 1:
             seqs_per_lineages = (max_gisaid_seqs - len(sampled_gisaid)) / (n_lineages - i + 1)
     return sampled_gisaid
 
 
-def write_user_sequences(fasta_output: Path, fout: IO[str], sequences: Path) -> None:
+def write_user_sequences(fout: IO[str], sequences: Path) -> int:
     count = 0
     with open(sequences) as fh:
         for name, seq in SimpleFastaParser(fh):
             fout.write(f'>{name}\n{seq}\n')
             count += 1
-    logging.info(f'Wrote {count} user sequences to "{fasta_output}"')
+    return count
 
 
 def write_nextstrain_metadata(df_filtered: pd.DataFrame, nextstrain_metadata: Path) -> None:
@@ -191,29 +291,48 @@ def write_nextstrain_metadata(df_filtered: pd.DataFrame, nextstrain_metadata: Pa
     df_subset_filtered.to_csv(nextstrain_metadata, sep='\t', index=True)
 
 
-def write_good_seqs(
-        header_seq_iterator: Iterator[Tuple[str, str]],
-        metadata_filtered_sequences: Set[str],
-        fasta_output_handle: IO[str],
+def write_filtered_gisaid_seqs(
+        handle: IO[str],
+        header_seqs: Iterator[Tuple[str, str]],
+        seq_ids: Set[str],
         min_length: int = 28000,
         max_length: int = 31000,
-        xambig: int = 3000
+        n_ambiguous: int = 3000
 ) -> Set[str]:
+    """Write GISAID sequences passing filters to FASTA file
+    
+    Filters include 
+    - GISAID sequence IDs that were filtered from metadata table based on Pangolin lineage and other metadata
+    - minimum length threshold
+    - maximum length threshold
+    - maximum number of ambiguous bases including N allowed in sequences
+    
+    Arguments:
+        handle: Output file handle
+        header_seqs: Iterator yielding tuple of header and sequence
+        seq_ids: GISAID sequence IDs to output
+        min_length: Minimum length of sequences
+        max_length: Maximum length of sequences
+        n_ambiguous: Max number of ambiguous bases in sequences
+
+    Returns:
+        Set of GISAID sequence names that were output
+    """
     keep_samples = set()
-    for strains, seq in header_seq_iterator:
+    for strains, seq in header_seqs:
         if '|' in strains:
             strains = strains.split('|')[0]
         if ' ' in strains:
             strains = strains.replace(' ', '_')
-        if strains not in metadata_filtered_sequences:
+        if strains not in seq_ids:
             continue
         if (
                 min_length < len(seq) <= max_length
-                and count_ambig_nt(seq) < xambig
+                and count_ambig_nt(seq) < n_ambiguous
                 and strains not in keep_samples
         ):
             keep_samples.add(strains)
-            fasta_output_handle.write(f'>{strains}\n{seq}\n')
+            handle.write(f'>{strains}\n{seq}\n')
     return keep_samples
 
 
@@ -225,7 +344,7 @@ def read_gisaid_metadata(gisaid_metadata: Path) -> pd.DataFrame:
         df = pd.read_table(gisaid_metadata, index_col=0)
     logging.info(f'Columns in GISAID metadata file: {df.columns}')
     # Replace non-word characters in column names with '_'
-    df.columns = df.columns.str.replace(r'[^\w]+', '_').str.replace(r'_+$', '')
+    df.columns = df.columns.str.replace(r'[^\w]+', '_', regex=True).str.replace(r'_+$', '', regex=True)
     # Strip whitespace from strain name
     df.index = df.index.str.replace(r'\s+', '_', regex=True)
     # Extract details of location into separate column
@@ -265,7 +384,7 @@ def read_fasta_tarxz(tarxz_path) -> Iterator[Tuple[str, str]]:
 
 def get_file_from_tar(tar: tarfile.TarFile, name: str) -> Optional[IO[bytes]]:
     while True:
-        file_member = tar.next()  # next() method is much faster than getnames() method
+        file_member = tar.next()
         if file_member is None:
             break
         if re.match(name, file_member.name):

--- a/bin/filter_gisaid.py
+++ b/bin/filter_gisaid.py
@@ -48,7 +48,8 @@ def main(
     df_pangolin = pd.read_csv(pangolin_report, dtype=str)
     df_pangolin.set_index(df_pangolin.columns[0], inplace=True)
     sample_lineages = set(df_pangolin['lineage'])
-    sample_lineages.remove('None')
+    if 'None' in sample_lineages:
+        sample_lineages.remove('None')
     logging.info(f'{len(sample_lineages)} unique Pangolin lineages for user sequences: {sample_lineages}')
     df_gisaid = read_gisaid_metadata(gisaid_tsv)
     logging.info(f'Read GISAID metadata table from "{gisaid_tsv}"; '

--- a/bin/filter_msa.py
+++ b/bin/filter_msa.py
@@ -90,8 +90,11 @@ def keep_seqs_from_country(df: pd.DataFrame, country: str, keep_samples: Set[str
     return keep_samples
 
 
-def quality_filter(keep_samples: Set[str], seq_samples: Mapping[str, Set[str]], df: pd.DataFrame) -> Tuple[
-    pd.DataFrame, Set[str]]:
+def quality_filter(
+        keep_samples: Set[str],
+        seq_samples: Mapping[str, Set[str]],
+        df: pd.DataFrame
+) -> Tuple[pd.DataFrame, Set[str]]:
     seq_recs = []
     for seq, samples in seq_samples.items():
         if samples & keep_samples:
@@ -123,7 +126,7 @@ def write_fasta(fasta_output: Path, keep_samples: Set[str], sample_seq: Dict[str
 
 def init_samples_to_keep(lineage_report: Path, ref_name: str) -> Set[str]:
     df_lineage_report = pd.read_csv(lineage_report, index_col=0)
-    keep_samples = set(df_lineage_report.index)
+    keep_samples = set(df_lineage_report.index.astype(str))
     keep_samples.add(ref_name)
     return keep_samples
 

--- a/bin/merge_metadata.py
+++ b/bin/merge_metadata.py
@@ -5,39 +5,55 @@ from typing import Optional
 
 import pandas as pd
 import typer
+from rich.console import Console
 from rich.logging import RichHandler
 
 
 def main(
-    metadata_input: Path,
-    pangolin_report: Path,
-    metadata_output: Path = typer.Option(Path('metadata.merged.tsv')),
-    aa_mutation_matrix: Optional[Path] = typer.Option(None, help='Amino acid mutation matrix TSV'),
-    select_metadata_fields: Optional[str] = typer.Option(None,
-                                                         help='Comma-delimited list of metadata fields to output. '
-                                                              'If unset, all metadata fields will be output.')
+        metadata_input: Path,
+        pangolin_report: Path,
+        metadata_output: Path = typer.Option(Path('metadata.merged.tsv')),
+        aa_mutation_matrix: Optional[Path] = typer.Option(None, help='Amino acid mutation matrix TSV'),
+        select_metadata_fields: Optional[str] = typer.Option(None,
+                                                             help='Comma-delimited list of metadata fields to output. '
+                                                                  'If unset, all metadata fields will be output.'),
+        user_metadata: Optional[Path] = typer.Option(None, help='User sequences metadata CSV or tab-delimited table.')
 ):
     """Merge a metadata table, Pangolin results table and AA mutation matrix into one table."""
     from rich.traceback import install
-    install(show_locals=True, width=120, word_wrap=True)
+    install(show_locals=True, width=120, word_wrap=True, console=Console(stderr=True))
     logging.basicConfig(
         format="%(message)s",
         datefmt="[%Y-%m-%d %X]",
         level=logging.INFO,
-        handlers=[RichHandler(rich_tracebacks=True, tracebacks_show_locals=True)],
+        handlers=[RichHandler(rich_tracebacks=True,
+                              tracebacks_show_locals=True,
+                              console=Console(stderr=True))],
     )
-    df_metadata = pd.read_table(metadata_input, index_col=0)
+    df_metadata = pd.read_table(metadata_input, dtype=str)
+    df_metadata.set_index(df_metadata.columns[0], inplace=True)
     logging.info(f'Read metadata table "{metadata_input}" with '
                  f'{df_metadata.shape[0]} rows and {df_metadata.shape[1]} columns')
     if select_metadata_fields:
         logging.info(f'Selecting specified metadata fields/columns from '
                      f'"{metadata_input}": {select_metadata_fields}')
         df_metadata = select_fields(df_metadata, select_metadata_fields)
+    if user_metadata:
+        logging.info(f'Reading user metadata table from "{user_metadata}". Assuming first column contains user '
+                     f'sequence IDs/names.')
+        df_user = read_user_metadata(user_metadata)
+        if df_user is not None:
+            logging.info(f'Combining user metadata table with shape {df_user.shape} '
+                         f'(columns={df_user.columns.tolist()}) with GISAID metadata table '
+                         f'(shape={df_metadata.shape}).')
+            df_metadata = df_user.combine_first(df_metadata)
+        else:
+            logging.warning(f'Empty user metadata table from "{user_metadata}"')
     dfs = [df_metadata]
     df_pangolin = read_pangolin_report(pangolin_report)
     dfs.append(df_pangolin)
     if aa_mutation_matrix:
-        dfs.append(pd.read_table(aa_mutation_matrix, index_col=0))
+        dfs.append(pd.read_table(aa_mutation_matrix, index_col=0, dtype=str))
     logging.info(f'Merging {len(dfs)} dataframes on index')
     df_merged = pd.concat(dfs, axis=1)
     if 'Pango_lineage' in df_merged.columns:
@@ -47,6 +63,27 @@ def main(
     logging.info(f'Writing merged dataframe with shape {df_merged.shape} to "{metadata_output}".')
     df_merged.to_csv(metadata_output, sep='\t', index=True)
     logging.info(f'Wrote merged dataframe with shape {df_merged.shape} to "{metadata_output}".')
+
+
+def read_user_metadata(user_metadata: Path) -> Optional[pd.DataFrame]:
+    ext = user_metadata.suffix
+    if ext == '.csv':
+        df_user = pd.read_csv(user_metadata, dtype=str)
+    elif ext in ['.tsv', '.txt']:
+        df_user = pd.read_table(user_metadata, dtype=str)
+    else:
+        logging.warning(f'Trying to read "{user_metadata}" as tab-delimited table.')
+        try:
+            df_user = pd.read_table(user_metadata, dtype=str)
+        except Exception as e:
+            logging.error(f'Could not read "{user_metadata}" as tab-delimited table. Error: {e}')
+            df_user = None
+    if df_user is None:
+        return None
+    if df_user.empty:
+        return None
+    df_user.set_index(df_user.columns[0], inplace=True)
+    return df_user
 
 
 def select_fields(df_metadata: pd.DataFrame, select_metadata_fields: str) -> pd.DataFrame:
@@ -60,7 +97,9 @@ def select_fields(df_metadata: pd.DataFrame, select_metadata_fields: str) -> pd.
 
 
 def read_pangolin_report(pangolin_report: Path) -> pd.DataFrame:
-    return pd.read_csv(pangolin_report, index_col=0)
+    df = pd.read_csv(pangolin_report, dtype=str)
+    df.set_index(df.columns[0], inplace=True)
+    return df
 
 
 if __name__ == '__main__':

--- a/bin/sequences_nextclade.py
+++ b/bin/sequences_nextclade.py
@@ -13,11 +13,13 @@ def main(
         output_sequences: Path = typer.Option('sequences.nextclade.fasta'),
         ref_name: str = typer.Option('MN908947.3', help='Reference sequence name')
 ):
-    df_metadata = pd.read_table(metadata_input, index_col=0)
-    df_pangolin = pd.read_csv(pangolin_report, index_col=0)
-    samples = set(df_metadata.index)
+    df_metadata = pd.read_table(metadata_input, dtype=str)
+    df_metadata.set_index(df_metadata.columns[0], inplace=True)
+    df_pangolin = pd.read_csv(pangolin_report, dtype=str)
+    df_pangolin.set_index(df_pangolin.columns[0], inplace=True)
+    samples = set(df_metadata.index.astype(str))
     samples.add(ref_name)
-    samples |= set(df_pangolin.index)
+    samples |= set(df_pangolin.index.astype(str))
     with open(input_sequences) as fin, open(output_sequences, 'w') as fout:
         for sample, seq in SimpleFastaParser(fin):
             if sample in samples:

--- a/conf/base.config
+++ b/conf/base.config
@@ -33,13 +33,13 @@ process {
     memory = { check_max( 32.GB * task.attempt, 'memory' ) }
     time = { check_max( 10.h * task.attempt, 'time' ) }
   }
+  withLabel:process_high_mem {
+    cpus = { check_max( 2 * task.attempt, 'cpus' ) }
+    memory = { check_max( 16.GB * task.attempt, 'memory' ) }
+    time = { check_max( 10.h * task.attempt, 'time' ) }
+  }
   withLabel:process_long {
     time = { check_max( 20.h * task.attempt, 'time' ) }
-  }
-  withLabel: 'process_iqtree' {
-    cpus = { check_max( 16 * task.attempt, 'cpus' ) }
-    memory = { check_max( 16.GB * task.attempt, 'memory' ) }
-    time = { check_max( 4.h * task.attempt, 'time' ) }
   }
   withLabel: 'process_high_cpu_low_mem' {
     cpus = { check_max( 16 * task.attempt, 'cpus' ) }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,7 +6,7 @@
 
 The pipeline has 2 workflows:
 
-* Phylogenetic analysis with input SARS-CoV-2 sequences
+* Phylogenetic analysis with your SARS-CoV-2 sequences
 
   ```bash
   nextflow run CFIA-NCFAD/scovtree \
@@ -14,14 +14,15 @@ The pipeline has 2 workflows:
     --input your-sars-cov-2-sequences.fasta
   ```
 
-* Phylogenetic analysis with input SARS-CoV-2 sequences and related GISAID sequences
+* Phylogenetic analysis with your SARS-CoV-2 sequences and GISAID sequences
 
   ```bash
   nextflow run CFIA-NCFAD/scovtree \
     -profile docker \
     --input your-sars-cov-2-sequences.fasta \
-    --gisaid_sequences sequences_fasta_2021_06_14.tar.xz \
-    --gisaid_metadata metadata_tsv_2021_06_14.tar.xz
+    --input_metadata your-sars-cov-2-sequences-metadata.tsv \
+    --gisaid_sequences sequences_fasta_2021_12_01.tar.xz \
+    --gisaid_metadata metadata_tsv_2021_12_01.tar.xz
   ```
 
   > Both `--gisaid_sequences` and `--gisaid_metadata` need to be specified to produce a phylogenetic tree of your sequences and closely related GISAID sequences.
@@ -488,29 +489,134 @@ You can also supply a run name to resume a specific run: `-resume [run-name]`. U
 
 Specify the path to a specific config file (this is a core Nextflow command). See the [nf-core website documentation](https://nf-co.re/usage/configuration) for more information.
 
-#### Custom resource requests
+## Custom configuration
 
-Each step in the pipeline has a default set of requirements for number of CPUs, memory and time. For most of the steps in the pipeline, if the job exits with an error code of `143` (exceeded requested resources) it will automatically resubmit with higher requests (2 x original, then 3 x original). If it still fails after three times then the pipeline is stopped.
+The following section is taken from the [nf-core/viralrecon usage docs](https://github.com/nf-core/viralrecon/blob/master/docs/usage.md#custom-configuration)
 
-Whilst these default requirements will hopefully work for most people with most data, you may find that you want to customise the compute resources that the pipeline requests. You can do this by creating a custom config file. For example, to give the workflow process `star` 32GB of memory, you could use the following config:
+### Resource requests
+
+Whilst the default requirements set within the pipeline will hopefully work for most people and with most input data, you may find that you want to customise the compute resources that the pipeline requests. Each step in the pipeline has a default set of requirements for number of CPUs, memory and time. For most of the steps in the pipeline, if the job exits with any of the error codes specified [here](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/conf/base.config#L18) it will automatically be resubmitted with higher requests (2 x original, then 3 x original). If it still fails after the third attempt then the pipeline execution is stopped.
+
+For example, if the nf-core/rnaseq pipeline is failing after multiple re-submissions of the `STAR_ALIGN` process due to an exit code of `137` this would indicate that there is an out of memory issue:
+
+```console
+[62/149eb0] NOTE: Process `RNASEQ:ALIGN_STAR:STAR_ALIGN (WT_REP1)` terminated with an error exit status (137) -- Execution is retried (1)
+Error executing process > 'RNASEQ:ALIGN_STAR:STAR_ALIGN (WT_REP1)'
+
+Caused by:
+    Process `RNASEQ:ALIGN_STAR:STAR_ALIGN (WT_REP1)` terminated with an error exit status (137)
+
+Command executed:
+    STAR \
+        --genomeDir star \
+        --readFilesIn WT_REP1_trimmed.fq.gz  \
+        --runThreadN 2 \
+        --outFileNamePrefix WT_REP1. \
+        <TRUNCATED>
+
+Command exit status:
+    137
+
+Command output:
+    (empty)
+
+Command error:
+    .command.sh: line 9:  30 Killed    STAR --genomeDir star --readFilesIn WT_REP1_trimmed.fq.gz --runThreadN 2 --outFileNamePrefix WT_REP1. <TRUNCATED>
+Work dir:
+    /home/pipelinetest/work/9d/172ca5881234073e8d76f2a19c88fb
+
+Tip: you can replicate the issue by changing to the process work dir and entering the command `bash .command.run`
+```
+
+To bypass this error you would need to find exactly which resources are set by the `STAR_ALIGN` process. The quickest way is to search for `process STAR_ALIGN` in the [nf-core/rnaseq Github repo](https://github.com/nf-core/rnaseq/search?q=process+STAR_ALIGN). We have standardised the structure of Nextflow DSL2 pipelines such that all module files will be present in the `modules/` directory and so based on the search results the file we want is `modules/nf-core/software/star/align/main.nf`. If you click on the link to that file you will notice that there is a `label` directive at the top of the module that is set to [`label process_high`](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/modules/nf-core/software/star/align/main.nf#L9). The [Nextflow `label`](https://www.nextflow.io/docs/latest/process.html#label) directive allows us to organise workflow processes in separate groups which can be referenced in a configuration file to select and configure subset of processes having similar computing requirements. The default values for the `process_high` label are set in the pipeline's [`base.config`](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/conf/base.config#L33-L37) which in this case is defined as 72GB. Providing you haven't set any other standard nf-core parameters to __cap__ the [maximum resources](https://nf-co.re/usage/configuration#max-resources) used by the pipeline then we can try and bypass the `STAR_ALIGN` process failure by creating a custom config file that sets at least 72GB of memory, in this case increased to 100GB. The custom config below can then be provided to the pipeline via the [`-c`](#-c) parameter as highlighted in previous sections.
 
 ```nextflow
 process {
-  withName: star {
-    memory = 32.GB
-  }
+    withName: STAR_ALIGN {
+        memory = 100.GB
+    }
 }
 ```
 
-To find the exact name of a process you wish to modify the compute resources, check the live-status of a nextflow run displayed on your terminal or check the nextflow error for a line like so: `Error executing process > 'bwa'`. In this case the name to specify in the custom config file is `bwa`.
+> **NB:** We specify just the process name i.e. `STAR_ALIGN` in the config file and not the full task name string that is printed to screen in the error message or on the terminal whilst the pipeline is running i.e. `RNASEQ:ALIGN_STAR:STAR_ALIGN`. You may get a warning suggesting that the process selector isn't recognised but you can ignore that if the process name has been specified correctly. This is something that needs to be fixed upstream in core Nextflow.
 
-See the main [Nextflow documentation](https://www.nextflow.io/docs/latest/config.html) for more information.
+### Tool-specific options
 
-If you are likely to be running `nf-core` pipelines regularly it may be a good idea to request that your custom config file is uploaded to the `nf-core/configs` git repository. Before you do this please can you test that the config file works with your pipeline of choice using the `-c` parameter (see definition above). You can then create a pull request to the `nf-core/configs` repository with the addition of your config file, associated documentation file (see examples in [`nf-core/configs/docs`](https://github.com/nf-core/configs/tree/master/docs)), and amending [`nfcore_custom.config`](https://github.com/nf-core/configs/blob/master/nfcore_custom.config) to include your custom profile.
+For the ultimate flexibility, we have implemented and are using Nextflow DSL2 modules in a way where it is possible for both developers and users to change tool-specific command-line arguments (e.g. providing an additional command-line argument to the `STAR_ALIGN` process) as well as publishing options (e.g. saving files produced by the `STAR_ALIGN` process that aren't saved by default by the pipeline). In the majority of instances, as a user you won't have to change the default options set by the pipeline developer(s), however, there may be edge cases where creating a simple custom config file can improve the behaviour of the pipeline if for example it is failing due to a weird error that requires setting a tool-specific parameter to deal with smaller / larger genomes.
 
-If you have any questions or issues please send us a message on [Slack](https://nf-co.re/join/slack) on the [`#configs` channel](https://nfcore.slack.com/channels/configs).
+The command-line arguments passed to STAR in the `STAR_ALIGN` module are a combination of:
 
-### Running in the background
+* Mandatory arguments or those that need to be evaluated within the scope of the module, as supplied in the [`script`](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/modules/nf-core/software/star/align/main.nf#L49-L55) section of the module file.
+
+* An [`options.args`](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/modules/nf-core/software/star/align/main.nf#L56) string of non-mandatory parameters that is set to be empty by default in the module but can be overwritten when including the module in the sub-workflow / workflow context via the `addParams` Nextflow option.
+
+The nf-core/rnaseq pipeline has a sub-workflow (see [terminology](https://github.com/nf-core/modules#terminology)) specifically to align reads with STAR and to sort, index and generate some basic stats on the resulting BAM files using SAMtools. At the top of this file we import the `STAR_ALIGN` module via the Nextflow [`include`](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/subworkflows/nf-core/align_star.nf#L10) keyword and by default the options passed to the module via the `addParams` option are set as an empty Groovy map [here](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/subworkflows/nf-core/align_star.nf#L5); this in turn means `options.args` will be set to empty by default in the module file too. This is an intentional design choice and allows us to implement well-written sub-workflows composed of a chain of tools that by default run with the bare minimum parameter set for any given tool in order to make it much easier to share across pipelines and to provide the flexibility for users and developers to customise any non-mandatory arguments.
+
+When including the sub-workflow above in the main pipeline workflow we use the same `include` statement, however, we now have the ability to overwrite options for each of the tools in the sub-workflow including the [`align_options`](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/workflows/rnaseq.nf#L225) variable that will be used specifically to overwrite the optional arguments passed to the `STAR_ALIGN` module. In this case, the options to be provided to `STAR_ALIGN` have been assigned sensible defaults by the developer(s) in the pipeline's [`modules.config`](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/conf/modules.config#L70-L74) and can be accessed and customised in the [workflow context](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/workflows/rnaseq.nf#L201-L204) too before eventually passing them to the sub-workflow as a Groovy map called `star_align_options`. These options will then be propagated from `workflow -> sub-workflow -> module`.
+
+As mentioned at the beginning of this section it may also be necessary for users to overwrite the options passed to modules to be able to customise specific aspects of the way in which a particular tool is executed by the pipeline. Given that all of the default module options are stored in the pipeline's `modules.config` as a [`params` variable](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/conf/modules.config#L24-L25) it is also possible to overwrite any of these options via a custom config file.
+
+Say for example we want to append an additional, non-mandatory parameter (i.e. `--outFilterMismatchNmax 16`) to the arguments passed to the `STAR_ALIGN` module. Firstly, we need to copy across the default `args` specified in the [`modules.config`](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/conf/modules.config#L71) and create a custom config file that is a composite of the default `args` as well as the additional options you would like to provide. This is very important because Nextflow will overwrite the default value of `args` that you provide via the custom config.
+
+As you will see in the example below, we have:
+
+* appended `--outFilterMismatchNmax 16` to the default `args` used by the module.
+* changed the default `publish_dir` value to where the files will eventually be published in the main results directory.
+* appended `'bam':''` to the default value of `publish_files` so that the BAM files generated by the process will also be saved in the top-level results directory for the module. Note: `'out':'log'` means any file/directory ending in `out` will now be saved in a separate directory called `my_star_directory/log/`.
+
+```nextflow
+params {
+    modules {
+        'star_align' {
+            args          = "--quantMode TranscriptomeSAM --twopassMode Basic --outSAMtype BAM Unsorted --readFilesCommand zcat --runRNGseed 0 --outFilterMultimapNmax 20 --alignSJDBoverhangMin 1 --outSAMattributes NH HI AS NM MD --quantTranscriptomeBan Singleend --outFilterMismatchNmax 16"
+            publish_dir   = "my_star_directory"
+            publish_files = ['out':'log', 'tab':'log', 'bam':'']
+        }
+    }
+}
+```
+
+### Updating containers
+
+The [Nextflow DSL2](https://www.nextflow.io/docs/latest/dsl2.html) implementation of this pipeline uses one container per process which makes it much easier to maintain and update software dependencies. If for some reason you need to use a different version of a particular tool with the pipeline then you just need to identify the `process` name and override the Nextflow `container` definition for that process using the `withName` declaration. For example, in the [nf-core/viralrecon](https://nf-co.re/viralrecon) pipeline a tool called [Pangolin](https://github.com/cov-lineages/pangolin) has been used during the COVID-19 pandemic to assign lineages to SARS-CoV-2 genome sequenced samples. Given that the lineage assignments change quite frequently it doesn't make sense to re-release the nf-core/viralrecon everytime a new version of Pangolin has been released. However, you can override the default container used by the pipeline by creating a custom config file and passing it as a command-line argument via `-c custom.config`.
+
+1. Check the default version used by the pipeline in the module file for [Pangolin](https://github.com/nf-core/viralrecon/blob/a85d5969f9025409e3618d6c280ef15ce417df65/modules/nf-core/software/pangolin/main.nf#L14-L19)
+2. Find the latest version of the Biocontainer available on [Quay.io](https://quay.io/repository/biocontainers/pangolin?tag=latest&tab=tags)
+3. Create the custom config accordingly:
+
+    * For Docker:
+
+        ```nextflow
+        process {
+            withName: PANGOLIN {
+                container = 'quay.io/biocontainers/pangolin:3.0.5--pyhdfd78af_0'
+            }
+        }
+        ```
+
+    * For Singularity:
+
+        ```nextflow
+        process {
+            withName: PANGOLIN {
+                container = 'https://depot.galaxyproject.org/singularity/pangolin:3.0.5--pyhdfd78af_0'
+            }
+        }
+        ```
+
+    * For Conda:
+
+        ```nextflow
+        process {
+            withName: PANGOLIN {
+                conda = 'bioconda::pangolin=3.0.5'
+            }
+        }
+        ```
+
+> **NB:** If you wish to periodically update individual tool-specific results (e.g. Pangolin) generated by the pipeline then you must ensure to keep the `work/` directory otherwise the `-resume` ability of the pipeline will be compromised and it will restart from scratch.
+
+## Running in the background
 
 Nextflow handles job submissions and supervises the running jobs. The Nextflow process must run until the pipeline is finished.
 
@@ -519,7 +625,7 @@ The Nextflow `-bg` flag launches Nextflow in the background, detached from your 
 Alternatively, you can use `screen` / `tmux` or similar tool to create a detached session which you can log back into at a later time.
 Some HPC setups also allow you to run nextflow within a cluster job submitted your job scheduler (from where it submits more jobs).
 
-#### Nextflow memory requirements
+## Nextflow memory requirements
 
 In some cases, the Nextflow Java virtual machines can start to request a large amount of memory.
 We recommend adding the following line to your environment to limit this (typically in `~/.bashrc` or `~./bash_profile`):

--- a/modules/local/filter_msa.nf
+++ b/modules/local/filter_msa.nf
@@ -26,6 +26,7 @@ process FILTER_MSA {
   output:
   path "msa.filtered.fasta", emit: fasta
   path "metadata.msa.tsv"  , emit: metadata
+  path "filter_msa.py.log" , emit: log
 
   script:  // This script is bundled with the pipeline, in /bin folder
   """
@@ -37,6 +38,7 @@ process FILTER_MSA {
     --country ${params.gisaid_focus_country} \\
     --max-seqs ${params.max_msa_seqs} \\
     --output-fasta msa.filtered.fasta \\
-    --output-metadata metadata.msa.tsv
+    --output-metadata metadata.msa.tsv \\
+    2>&1 | tee -a filter_msa.py.log
   """
 }

--- a/modules/local/iqtree.nf
+++ b/modules/local/iqtree.nf
@@ -5,7 +5,7 @@ params.options = [:]
 options        = initOptions(params.options)
 
 process IQTREE {
-  label 'process_iqtree'
+  label 'process_high'
   publishDir "${params.outdir}",
       mode: params.publish_dir_mode,
       saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }

--- a/modules/local/merge_metadata.nf
+++ b/modules/local/merge_metadata.nf
@@ -20,6 +20,7 @@ process MERGE_METADATA{
   path(gisaid_metadata)
   path(aa_mutation_matrix)
   path(pangolin_report)
+  path(user_metadata)
 
   output:
   path "metadata.merged.tsv"
@@ -27,11 +28,12 @@ process MERGE_METADATA{
   script:  // This script is bundled with the pipeline, in /bin folder
   def aa_mutation_matrix_opt = (aa_mutation_matrix) ? "--aa-mutation-matrix $aa_mutation_matrix" : ""
   def select_metadata_fields = (params.select_gisaid_metadata) ? "--select-metadata-fields \"${params.select_gisaid_metadata}\"" : ""
+  def user_metadata_opt = (user_metadata) ? "--user-metadata $user_metadata" : ""
   """
   merge_metadata.py \\
     $gisaid_metadata \\
     $pangolin_report \\
-    $aa_mutation_matrix_opt $select_metadata_fields \\
+    $aa_mutation_matrix_opt $select_metadata_fields $user_metadata_opt \\
     --metadata-output metadata.merged.tsv
   """
 }

--- a/modules/local/pangolin.nf
+++ b/modules/local/pangolin.nf
@@ -10,13 +10,12 @@ process PANGOLIN {
       mode: params.publish_dir_mode,
       saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
-  conda (params.enable_conda ? 'bioconda::pangolin=3.1.16' : null)
+  conda (params.enable_conda ? 'bioconda::pangolin=3.1.17' : null)
   if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-    container 'https://depot.galaxyproject.org/singularity/pangolin:3.1.16--pyhdfd78af_0'
+    container 'https://depot.galaxyproject.org/singularity/pangolin:3.1.17--pyhdfd78af_1'
   } else {
-    container 'quay.io/biocontainers/pangolin:3.1.16--pyhdfd78af_0'
+    container 'quay.io/biocontainers/pangolin:3.1.17--pyhdfd78af_1'
   }
-
 
   input:
   path(fasta)
@@ -24,14 +23,16 @@ process PANGOLIN {
   output:
   path 'pangolin.csv' , emit: report
   path '*.version.txt', emit: version
+  path 'pangolin.log' , emit: log
 
   script:
   def software = getSoftwareName(task.process)
   """
   pangolin \\
-      $fasta \\
-      --outfile pangolin.csv \\
-      --threads $task.cpus
+    $fasta \\
+    --outfile pangolin.csv \\
+    --threads $task.cpus
+  ln -s .command.log pangolin.log
 
   pangolin --version | sed "s/pangolin //g" > ${software}.version.txt
   """

--- a/modules/local/prune_tree.nf
+++ b/modules/local/prune_tree.nf
@@ -20,7 +20,7 @@ process PRUNE_TREE {
 
   input:
   path (newick)
-  path (lineage_report)
+  path (pangolin_report)
   path (metadata)
 
   output:
@@ -32,7 +32,7 @@ process PRUNE_TREE {
   prune_tree.py \\
     $newick \\
     $metadata \\
-    --lineage-report $lineage_report \\
+    $pangolin_report \\
     --ref-name ${params.reference_name} \\
     --leaflist leaflist \\
     --metadata-output metadata.leaflist.tsv \\

--- a/modules/local/shiptv.nf
+++ b/modules/local/shiptv.nf
@@ -25,6 +25,7 @@ process SHIPTV {
   path 'shiptv.html'        , emit: html
   path 'metadata.shiptv.tsv', emit: metadata
   path '*.version.txt'      , emit: version
+  path 'shiptv.log'         , emit: log
 
   script:
   """
@@ -35,6 +36,7 @@ process SHIPTV {
     --outgroup ${params.reference_name} \\
     --output-html shiptv.html \\
     --output-metadata-table metadata.shiptv.tsv
+  ln -s .command.log shiptv.log
 
   shiptv --version | sed 's/shiptv version //' > shiptv.version.txt
   """

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,6 +11,7 @@ params {
   reference_name                    = 'MN908947.3'
   reference_fasta                   = 'https://github.com/CFIA-NCFAD/nf-test-datasets/raw/scovtree/genome/MN908947.3/MN908947.3.fa'
   substitution_model                = 'GTR'
+  input_metadata                    = ''
 
   //Input options for filtering sequence against GISAID Database
   gisaid_sequences                  = ''
@@ -20,6 +21,9 @@ params {
   gisaid_min_length                 = 28000
   gisaid_max_length                 = 31000
   gisaid_max_ambig                  = 3000
+  gisaid_date_start                 = ''
+  gisaid_date_end                   = ''
+  gisaid_pangolin_lineages          = ''
   max_gisaid_filtered_seqs          = 100000
 
   //Options for filtering MSA
@@ -171,8 +175,8 @@ manifest {
   homePage = 'https://github.com/CFIA-NCFAD/scovtree'
   description = 'Phylogenetic Analysis for SARS-CoV-2'
   mainScript = 'main.nf'
-  nextflowVersion = '!>=21.04.0'
-  version = '1.5.1'
+  nextflowVersion = '>=21.04.0'
+  version = '1.6.0'
 }
 
 // Function to ensure that resource requirements don't go beyond

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -16,6 +16,11 @@
                     "fa_icon": "fas fa-dna",
                     "description": "Path to FASTA file with SARS-CoV-2 sequences."
                 },
+                "input_metadata": {
+                    "type": "string",
+                    "fa_icon": "fas fa-table",
+                    "description": "Path to CSV or tab-delimited table with metadata for user's input SARS-CoV-2 sequences."
+                },
                 "outdir": {
                     "type": "string",
                     "description": "The output directory where the results will be saved.",
@@ -63,6 +68,23 @@
                     "default": "",
                     "description": "Select GISAID sequences from a particular geographical region.",
                     "fa_icon": "fas fa-folder-open"
+                },
+                "gisaid_date_start": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Filter for GISAID sequences collected starting on a specified ISO format date (e.g. 2021-06-09 for June 9, 2021)",
+                    "fa_icon": "fas fa-calendar"
+                },
+                "gisaid_date_end": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Filter for GISAID sequences collected ending on a specified ISO format date (e.g. 2021-06-09 for June 9, 2021)",
+                    "fa_icon": "fas fa-calendar"
+                },
+                "gisaid_pangolin_lineages": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Filter for GISAID sequences with specified comma-delimited Pangolin lineages (e.g. \"AY.44,AY.4\" to filter for lineages AY.44 and AY.4 as well as whatever your input sequences are classified as)"
                 },
                 "gisaid_min_length": {
                     "type": "integer",

--- a/workflows/phylogenetic_gisaid.nf
+++ b/workflows/phylogenetic_gisaid.nf
@@ -23,6 +23,7 @@ workflow PHYLOGENETIC_GISAID {
   ch_gisaid_metadata  = Channel.fromPath(params.gisaid_metadata)
   ch_reference_fasta  = Channel.fromPath(params.reference_fasta)
   ch_input            = Channel.fromPath(params.input)
+  ch_input_metadata   = (params.input_metadata) ? Channel.fromPath(params.input_metadata) : Channel.empty()
 
   PREPARE_INPUT_SEQUENCES(ch_input)
 
@@ -72,7 +73,8 @@ workflow PHYLOGENETIC_GISAID {
   MERGE_METADATA(
     PRUNE_TREE.out.metadata,
     ch_aa_mutation_matrix.ifEmpty([]),
-    PANGOLIN.out.report
+    PANGOLIN.out.report,
+    ch_input_metadata.ifEmpty([])
   )
   SHIPTV(
     IQTREE.out.treefile,


### PR DESCRIPTION
### Updates

- Pangolin: 3.1.16 → 3.1.17

### Enhancements

- Nextclade amino acid (AA) deletions also included in AA mutation matrix and can be visualized along with AA substitutions in shiptv tree.
- Users can filter GISAID sequences by collection date (`--gisaid_date_start`, `--gisaid_date_end`), Pangolin lineage (`--gisaid_pangolin_lineages "AY.4,AY44"`), multiple countries and regions.  
- users can specify input sequence metadata table with `--input_metadata` workflow parameter. Must be CSV or TSV file.
- update usage docs to include how to update process containers/packages (e.g. update Pangolin without changing workflow). Borrowed from nf-core/viralrecon.
- Log files now output for most processes.

### Fixes

- allocate more memory for `FILTER_GISAID` process by default (6GB -> 16GB) due to growing size of GISAID DB
- handle all metadata as string so that numeric sequence IDs are not treated as int/float leading to issues with merging of metadata and tracking sequences to keep for further analysis


## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [X] Usage Documentation in `docs/usage.md` is updated.
- [X] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [X] `README.md` is updated (including new tool citations and authors/contributors).
